### PR TITLE
Doc updates for rel 6.6.0

### DIFF
--- a/docs/reference/btcli.md
+++ b/docs/reference/btcli.md
@@ -52,6 +52,19 @@ btcli wallet overview --help
 ```
 for full options.
 
+### Show history
+
+```bash
+btcli wallet history --wallet.name <YOUR WALLET NAME>
+```
+
+Displays the last 1000 transactions performed with `<YOUR WALLET NAME>` by querying the [Taostats](https://taostats.io/) GraphQL indexer. It shows the `From`, `To`, `Amount`, `Extrinsic Id` and `Block Number`.
+
+Run,
+```bash
+btcli wallet history --help
+```
+for help.
 
 ### List wallets
 

--- a/docs/whats-new-in-docs.md
+++ b/docs/whats-new-in-docs.md
@@ -9,6 +9,10 @@ hide_table_of_contents: false
 
 Key updates to this documentation.
 
+## 10 January 2024 (DRAFT)
+
+- Added the `btcli wallet history` [command description](./reference/btcli.md#show-history).  
+
 ## 02 January 2024
 
 - Added a new doc [Staking with Polkadot JS](./staking/staking-polkadot-js.md).


### PR DESCRIPTION
Note: Last year we removed the https://github.com/opentensor/new-docs/blob/main/docs/reference/bittensor-api-ref.md file because it duplicated much of the Bittensor API Reference section. Hence, for the `subtensor.close()` method, I will update the API Reference section soon, which will capture the new `close()` method description. 