### PR TITLE
Adding a section for subnet pages in the homepage 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -132,6 +132,12 @@ You can participate in an existing subnet as either a subnet validator or a subn
 
 ---
 
+## Subnet pages
+
+See [Subnet Pages](./subnet-pages/index.md) for a brief description of each subnet.
+
+---
+
 ## Running a subnet
 
 Ready to run your own subnet? Follow the below links.


### PR DESCRIPTION
This is because the top navbar item is removed.