### PR TITLE
change evm testnet URL

### DIFF
--- a/docs/evm-tutorials/hardhat-config-for-subtensor-evm.md
+++ b/docs/evm-tutorials/hardhat-config-for-subtensor-evm.md
@@ -12,7 +12,7 @@ You can use [Hardhat](https://hardhat.org/) development environment for the EVM 
 The below code configures two subtensor EVM networks for Hardhat: 
 
 1. EVM Localnet with URL: http://127.0.0.1:9946
-2. EVM Testnet with URL: https://evm-testnet.dev.opentensor.ai
+2. EVM Testnet with URL: https://test.chain.opentensor.ai
 
 :::tip Full example
 See [ERC-20 Example Token repository](https://github.com/gztensor/subtensor-erc20) for a complete example of `hardhat.config.ts` configuration.
@@ -24,7 +24,7 @@ const hardhatConfig: HardhatUserConfig = {
   defaultNetwork: "subevm",
   networks: {
     subevm: {
-      url: "https://evm-testnet.dev.opentensor.ai",
+      url: "https://test.chain.opentensor.ai",
       accounts: [config.ethPrivateKey]
     },
     local: {

--- a/docs/evm-tutorials/transfer-from-metamask-to-ss58.md
+++ b/docs/evm-tutorials/transfer-from-metamask-to-ss58.md
@@ -123,7 +123,7 @@ You will need the private key for your SS58 for this method.
 5. Copy the "Ethereum mirror:" output address.
 6. Transfer the amount to this address that you wish to transfer using Metamask. Make sure to clear activity tab data if you restarted the network previously: **Settings** > **Advanced** > **Clear activity tab data**.
 7. Make sure your destination address is funded to run a transaction.
-8. Open the **Extrisics** section in Polkadot JS app: [https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fevm-testnet.dev.opentensor.ai%3A443#/extrinsics](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fevm-testnet.dev.opentensor.ai%3A443#/extrinsics).
+8. Open the **Extrisics** section in Polkadot JS app: [https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ftest.chain.opentensor.ai%3A443#/extrinsics](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ftest.chain.opentensor.ai%3A443#/extrinsics).
 9. Select `evm` pallet and `withdraw` extrinsic.
 10. Paste the "Ethereum mirror" output address into address field.
 11. Put the amount you are transferring into amount field. Note that Metamask balances are by 10^9 lower than Polkadot Apps UI balances because Metamask will not respect 10^9 decimals for native currency before we have a corresponding PR to https://github.com/ethereum-lists merged.


### PR DESCRIPTION
This PR replaces the old EVM testnet URL `https://evm-testnet.dev.opentensor.ai` with the current testnet URL `https://test.chain.opentensor.ai`