### PR TITLE
Fixup typo

### DIFF
--- a/docs/dynamic-tao/index.md
+++ b/docs/dynamic-tao/index.md
@@ -20,7 +20,7 @@ Testnet tokens do not have any value.
 Most operations will remain unchanged, including the main workflows for miners (e.g., registering on subnets) and validators (e.g., setting weights).
 Simply update the Bittensor SDK and/or `btcli`, and you will be prepared to work with the Dynamic TAO-enabled Bittensor test network.
 
-To update to the the Dynamic TAO-enbaled versions of the tooling, run:
+To update to the Dynamic TAO-enabled versions of the tooling, run:
 
 ```
 # update the SDK to the most recent dTao enabled release candidate

--- a/docs/dynamic-tao/index.md
+++ b/docs/dynamic-tao/index.md
@@ -24,9 +24,9 @@ To update to the Dynamic TAO-enabled versions of the tooling, run:
 
 ```
 # update the SDK to the most recent dTao enabled release candidate
-pip install bittensor==8.5.1rc5
+pip install bittensor==8.5.1rc6
 # update BTCLI to the most recent dTao enabled release candidate
-pip install bittensor-cli==8.2.0rc9
+pip install bittensor-cli==8.2.0rc10
 ```
 
 :::danger


### PR DESCRIPTION
- Removed a duplicate `the` and updated spelling of `enabled`
- Updated bittensor versions to the latest release candidates