### PR TITLE
Continue efforts to remove non-preferred words that sound too financey

### DIFF
--- a/docs/btcli.md
+++ b/docs/btcli.md
@@ -240,7 +240,7 @@ $ btcli root boost [OPTIONS]
 
 Stakes TAO to a specified delegate on the Bittensor network.
 
-This action allocates the user's TAO to support a delegate, potentially earning staking rewards in return.
+This action allocates the user's TAO to support a delegate, giving them greater consensus weight and emissions. In return, stakers extract a portion of the delegate validator's emissions.
 
 The command interacts with the user to determine the delegate and the amount of TAO to be staked. If the
 `--all` flag is used, it delegates the entire available balance.
@@ -286,11 +286,7 @@ $ btcli root delegate-stake [OPTIONS]
 
 ### btcli root get-weights
 
-Retrieve the weights set for the root network on the Bittensor network. This command provides visibility into how network responsibilities and rewards are distributed among various
-subnets.
-
-The command outputs a table listing the weights assigned to each subnet within the root network. This
-information is crucial for understanding the current influence and reward distribution among the subnets.
+Retrieve the weights set for the root network on the Bittensor network. A subnet's weight determines its current influence and emissions releative to other subnets.
 
 #### Example
 
@@ -298,9 +294,6 @@ information is crucial for understanding the current influence and reward distri
 btcli root get-weights
 ```
 
-:::tip
-This command is essential for users interested in the governance and operational dynamics of the Bittensor network. It offers transparency into how network rewards and responsibilities are allocated across different subnets.
-:::
 
 **Usage**:
 
@@ -751,9 +744,9 @@ $ btcli root set-take [OPTIONS]
 
 ### btcli root set-weights
 
-Set the weights for the oot network on the Bittensor network.
+Set the weights for the root network on the Bittensor network.
 
-This command is used by network senators to influence the distribution of network rewards and responsibilities.
+This command is used by network senators to influence the weight of subnets within the network.
 
 The command allows setting weights for different subnets within the root network. Users need to specify the
 netuids (network unique identifiers) and corresponding weights they wish to assign.
@@ -764,8 +757,8 @@ netuids (network unique identifiers) and corresponding weights they wish to assi
 btcli root set-weights -w 0.3,0.3,0.4 -n 1,2,3 --chain ws://127.0.0.1:9945
 ```
 
-:::tip
-This command is particularly important for network senators and requires a comprehensive understanding of the network's dynamics. It is a powerful tool that directly impacts the network's operational mechanics and reward distribution.
+:::danger
+This command is particularly important for network senators and requires a comprehensive understanding of the network's dynamics.
 :::
 
 **Usage**:
@@ -850,7 +843,7 @@ send a transaction to the Bittensor network to process the undelegation.
 ```
 
 :::tip
-This command can result in a change to the blockchain state and may incur transaction fees. It is interactive and requires confirmation from the user before proceeding. It should be used with care as undelegating can affect the delegate's total stake and potentially the user's staking rewards.
+This command can result in a change to the blockchain state and may incur transaction fees. It is interactive and requires confirmation from the user before proceeding. It should be used with care as it affects the delegate's total stake and emissions to the user.
 :::
 
 **Usage**:
@@ -1877,11 +1870,10 @@ Obtain test TAO tokens by performing Proof of Work (PoW).
 This command is particularly useful for users who need test tokens for operations on a local chain.
 
 :::warning Alert
-This command is disabled on finney (mainnet) and testnet.
+This command is disabled on finney (mainnet) and testnet. It is only used in local chain environments.
 :::
 
-The command uses the PoW mechanism to validate the user's effort and rewards them with test TAO tokens. It is
-typically used in local chain environments where real value transactions are not necessary.
+
 
 #### Example
 
@@ -2017,7 +2009,7 @@ The resulting table includes columns for:
 
 - _Stake_: The amount of stake held by both the coldkey and hotkey.
 
-- _Emission_: The emission or rewards earned from staking.
+- _Emission_: The quantity of emissions from staking.
 
 - _Netuid_: The network unique identifier of the subnet where the hotkey is active.
 

--- a/docs/dynamic-tao/dtao-faq.md
+++ b/docs/dynamic-tao/dtao-faq.md
@@ -49,7 +49,7 @@ Instead of staking TAO to a validator, in Dynamic TAO, you stake to a validator 
 
 - When you stake on a mining subnet, you exchange TAO for a dynamic token, the *alpha* of the subnet on which the validator is working, and stake that into the validator's hotkey.
 
-- When you stake on the root subnet, you stake TAO for TAO. You will receive TAO as dividends, unlike receiving alphas on other subnets.
+- When you stake on the root subnet, you stake TAO for TAO. You will receive emissions in TAO.
 
 ### What is the risk/reward profile of staking into a subnet?
 

--- a/docs/emissions.md
+++ b/docs/emissions.md
@@ -19,9 +19,7 @@ The emission process works like this:
     :::tip Taostats
     See the [percentage numbers in each "**SN**" column on the root network page on Taostats](https://taostats.io/subnets/netuid-0/). These percentages for all SNs add up to `100`. 
     :::
-- At the end of every tempo, i.e., every 360 blocks in a user-created subnet, the TAO ($\tau$) accumulated for each subnet is emitted into the subnet. This emitted TAO for the subnet is then distributed within the subnet as:
-  - **Dividends** to the subnet validators, and 
-  - **Incentives** to the subnet miners.
+- At the end of every tempo, i.e., every 360 blocks in a user-created subnet, the TAO ($\tau$) accumulated for each subnet is injected into the subnet. This emitted TAO for the subnet is then allocated among the subnet's miners, validators, and their stakers, as well as the subnet creator.
 
 ## Before you proceed
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -86,10 +86,6 @@ The process of removing a subnet miner or a subnet validator from the subnet due
 
 The process by which newly minted TAO tokens (emissions) are allocated among subnet miners and subnet validators, based on their performance, the amount of stake associated with the subnet validators' UIDs, and the Yuma Consensus algorithm.
 
-### Dividends
-
-A portion of the TAO emission received by subnet validators as a reward for their participation in validating transactions and maintaining the integrity of a subnet.
-
 ## E 
 
 ### EdDSA Cryptographic Keypairs

--- a/docs/subnets/understanding-subnets.md
+++ b/docs/subnets/understanding-subnets.md
@@ -9,7 +9,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 In Bittensor, a subnet is an incentive-based competition marketplace that produces a specific kind of digital commodity related to artificial intelligence. It consists of a community of miners that produce the commodity, and a community of validators that measures the miners' work to ensure its quality. Often, parties that serve as validators do so in order to run applications that make use of the services provided by the miners.
 
-Rewards&mdash;emmissions of TAO (τ) from Bittensor&mdash;are distributed among miners and validators based on their performance within subnets, and based on the relative performance of subnets within Bittensor.
+Emissions of TAO (τ) from Bittensor&mdash;are distributed among miners and validators based on their performance within subnets, and based on the relative performance of subnets within Bittensor.
 
 ## Anatomy of a subnet
 
@@ -18,7 +18,7 @@ The illustration below shows the main components of a subnet:
 2. **Miners** perform some useful work as defined in the subnet's incentive mechanism. For example, in Subnet 1, miners serve chat prompt completion.
 3. **Validators** independently evaluate the task performed by the subnet miners, according to standards defined by the subnet's incentive mechanism.
 4. Validators each score the performance of of each miner over the most recent time period. The matrix of these scores, by each validator for each miner, serves as input to **Yuma Consensus**. 
-5. The Yuma Consensus algorithm operates on-chain, and determines the distribution of TAO (τ) rewards to miners, validators, and subnet owners across the platform, based on performance.
+5. The Yuma Consensus algorithm operates on-chain, and determines emissions to miners, validators, and subnet owners across the platform, based on performance.
 
 <center>
 <ThemedImage

--- a/docs/yuma-consensus.md
+++ b/docs/yuma-consensus.md
@@ -27,11 +27,11 @@ print ('weights', subnet.W )
 
 ## Ranks, trust, consensus, incentive 
 
-The Yuma Consensus algorithm translates the weight matrix $W$ into incentives for the subnet miners and dividends for the subnet validators.
+The Yuma Consensus algorithm translates the weight matrix $W$ into incentives for the subnet's miners and validators.
 
 However, radical divergence from consensus view points is dangerous, especially if bad actor validators manipulate incentives in ways that benefits themselves, for example, lying about the value produced by miners. 
 
-To avoid this scenario Bittensor uses a mechanism called Yuma Consensus. The Yuma Consensus rewards subnet validators with **dividends** for producing miner-value evaluations that are in agreement with the subjective evaluations produced by other subnet validators, weighted by **stake**.
+To avoid this scenario Bittensor uses a mechanism called Yuma Consensus. The Yuma Consensus incentivizes subnet validators to produce miner-value evaluations that are in agreement with those of other subnet validators, weighted by **stake**.
 
 The below example code prints the values of `S`, subnet validator stake, and `W`, subnet validator weights for a subnet with the `netuid` of `1`:
 


### PR DESCRIPTION


throughout the docs we are moving away from the following terms:

    reward(s)
    dividends
    distribute/distribution
    earn
    recieve/send (emissions)
    subnet owner

we prefer:

    TAO (and alpha) are emitted by Bittensor to participants
    Participants mine or extract TAO/alpha
    Allocation rather than distribution
    incentiv(e/ize) rather than reward
    Credit/debit (emissions to a participant)
    Subnet Creator
    avoid language that sounds financial

