### PR TITLE
Rewards be gone part 4

### DIFF
--- a/docs/learn/anatomy-of-incentive-mechanism.md
+++ b/docs/learn/anatomy-of-incentive-mechanism.md
@@ -7,19 +7,19 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Understanding Incentive Mechanisms
 
-This page explores the concept and usage of incentive mechansisms in Bittensor. See [Components of the Bittensor platform] for an explanation of the basics, such as subnets, miners, validators, and the role of the blockchain.
+This page explores the concept and usage of incentive mechansisms in Bittensor
 
-Each subnet has its own *incentive mechanism*, which drives the behavior of its community of miners and validators by defining a standard model for how miner's work is to be evaluated. Miners are incentivized to meet this standard so validators will score (or 'weight') their work highly, resulting in higher TAO (τ) rewards for the miners. Validators are incentivized to accurately score miners' work according to this standard so that their scoring is close to consensus, resulting in higher TAO (τ) rewards for the validators.
+See [Components of the Bittensor platform](../learn/bittensor-building-blocks) for an explanation of the basics, such as subnets, miners, validators, and the role of the blockchain.
 
-:::danger 
+Each subnet has its own *incentive mechanism*, which drives the behavior of its community of miners and validators by defining a standard model for how miner's work is to be evaluated. Miners are incentivized to meet this standard so validators will score (or 'weight') their work highly, resulting in higher emissions. Validators are incentivized to accurately score miners' work according to this standard because the algorithm penalizes departure from consensus in miner scores with lower emissions.
+
 A well-designed incentive mechanism is critical for a well-functioning subnet! Carefully consider and test the consequences of the behaviors you will be incentivizing and punishing before releasing your IM to your subnet on the main Bittensor network.
-:::
 
 A subnet incentive mechanism, when running optimally on a subnet, will continuously produce high quality results because the subnet miners and subnet validators are incentivized to do so. Furthermore, a good incentive mechanism will encourage **continuous improvement** of the subnet as a whole by leveraging the competition between miners to attain ever higher scores.
 
-## Subnet owner responsibilities
+## Subnet creator responsibilities
 
-A subnet owner is responsible for:
+A subnet creator is responsible for:
 - Defining the specific digital task to be performed by the subnet miners.
 - Implementing an incentive mechanism that aligns miners with the desired task outcomes.
 
@@ -43,40 +43,39 @@ After a subnet validator registers into your subnet, they will run the validator
 
 ## Components of incentive mechanism
 
-A subnet incentive mechanism must contain the definition and implementation of the following behaviors. See the numbered items in the below diagram:
+A subnet incentive mechanism must provide the following:
 
-<ThemedImage
-alt="Components of Incentive Mechanism"
-sources={{
-    light: useBaseUrl('/img/docs/components-of-incentive-mechanism.svg'),
-    dark: useBaseUrl('/img/docs/dark-components-of-incentive-mechanism.svg'),
-  }}
-/>
+- A protocol for how validators query miners and how miners respond
+- A task definition for the work miners are to perform
+- A scoring mechanism for validators to use in evaluating miners' work
 
-### Subnet protocol
-See **1** and **3** in the above diagram. A subnet protocol, which is unique to the subnet, must define how a subnet validator will query the subnet miners, and how a subnet miner should respond to the query. 
 
-:::tip Axon, dendrite and Synapse building blocks
-Use the Bittensor building blocks Axon, dendrite and Synapse to develop your subnet protocol. See [Neuron to neuron communication](./bittensor-building-blocks.md#neuron-to-neuron-communication).
-:::
+### Miner-validator protocol
 
-For example, a subnet validator might send a query containing the task description to the subnet miners. The subnet miners will perform the task and then respond to the subnet validators with the results of the task the miners performed. Note, however, that query-response is only one of the ways of subnet miner-and-subnet validator interaction. An alternative example is when the subnet validators and subnet miners use additional shared resources such as databases, and these resources can be used to evaluate miner performance.
+A subnet creator must define a protocol for how validators are to query miners, and how miners should respond. Protocols are built using the Axon-Dendrite client-server model and and Synapse data objects.
+
+See [Neuron to neuron communication](./bittensor-building-blocks.md#neuron-to-neuron-communication).
+
 
 ### Subnet task
-See **2** in the above diagram. The task is one of the key components of any incentive mechanism as it defines what miners will perform as work. The task should be chosen so that miners are maximally effective at the intended use case for the subnet. In other words, **the task should mimic an intended user interaction with a subnet**. Examples of tasks are responding to natural language prompts and storing encrypted files.
+
+The task is one of the key components of any incentive mechanism as it defines what miners will perform as work. The task should be chosen so that miners are maximally effective at the intended use case for the subnet.
+
+In other words, **the task should mimic an intended user interaction with a subnet**. Examples of tasks are responding to natural language prompts and storing encrypted files.
 
 :::tip Aligning miners with the subnet goals
 The task defines the scope of work that miners will undertake, and what utility the subnet can provide to users. In some cases this should be very specific (such as storage) and in other cases it can be varied (many types of natural language query). 
 :::
 
-### Subnet reward model
-See **4** and **5** in the above diagram. Just as the task describes **what** miners should do, the reward model dictates **how** it should be done. Similarly, just as tasks should mimic user interactions, reward models should mimic user preferences or desired outcomes.
+### Subnet scoring model
 
-As with any machine learning model, a subnet has an objective function that it is continuously optimizing. The reward model defines the quality of all miner behaviour in the subnet (both intended and unintended). 
+Where the task describes **what** miners should do, the scoring model dictates **how** it should be done. Similarly, just as tasks should mimic user interactions, scoring models should mimic user preferences or desired outcomes.
 
-Operationally, it is the mathematical object that converts miner responses into numerical scores. A reward model can in fact contain as many different reward mechanisms as are necessary to align miners with the intended task. 
+As with any machine learning model, a subnet has an objective function that it is continuously optimizing. The scoring model defines the quality of all miner behaviour in the subnet (both intended and unintended). 
 
-Miners will continuously compete to achieve the highest reward possible. If the reward is capped at an upper limit, miners may not be motivated to improve further. Hence care should be taken to enable continuous improvement of the miner, rather than stagnation.
+Operationally, it is the mathematical object that converts miner responses into numerical scores. A scoring model can in fact contain as many different scoring mechanisms as are necessary to align miners with the intended task. 
+
+Miners will continuously compete to achieve the highest score possible, since it determines their emissions. If the score is capped at an upper limit, miners may not be motivated to improve further. Hence care should be taken to enable continuous improvement of the miner, rather than stagnation.
 
 :::tip The zen of incentive mechanisms
 Subnets should be endlessly improving.
@@ -88,38 +87,13 @@ The incentive mechanism is ultimately the judge of subnet miner performance. Whe
 On the contrary, a poorly designed incentive mechanism can result in exploits and shortcuts, which can detrimentally impact the overall quality of the subnet and discourage fair miners.
 
 
-## Distribution of rewards
+## Allocation of emissions
 
-### Example
 
-Distribution of rewards among the subnet miners and subnet validators works like this. Consider an example subnet:
-- Three subnet miners occupy the UID slots 37, 42 and 27 in the subnet.
-- Four subnet validators occupy the UID slots 10, 32, 93 and 74 in the subnet, as shown in the below simplified conceptual diagram. Assume that the **subnet protocol** box in the diagram includes all the components of the incentive mechanism that were identified above.
+1. Each validator on the subnet computes a vector of weights assigned to each miner, representing an aggregate ranking based on their performance. Validators transmit these **weight vectors** to the blockchain. Typically each subnet validator transmits an updated ranking weight vector to the blockchain every 100-200 blocks. 
+2. The Bittensor blockchain waits for the latest ranking weight vectors from all the subnet validators of a given subnet, then forms a **weight matrix** formed from these ranking/weight vectors is then provided as input to the Yuma Consensus module on-chain.
+3. The Yuma Consensus (YC) uses this weight matrix, along with the amount of stake associated with each UID on the subnet, to calculate emissions to each subnet and each participant within each subnet, which are finalized and debited to participants' hotkeys at the end of each *tempo* or 360 blocks.
 
-<ThemedImage
-alt="Incentive Mechanism Big Picture"
-sources={{
-    light: useBaseUrl('/img/docs/distribution-of-rewards-big-picture.svg'),
-    dark: useBaseUrl('/img/docs/dark-distribution-of-rewards-big-picture.svg'),
-  }}
-/>
-
-The item numbers below correspond to the circled numbers in the above diagram.
-
-1. Each subnet validator maintains a vector of weights. Each element of the vector represents the weight assigned to a subnet miner. This weight represents how well the subnet miner is performing **according to this subnet validator**. 
-   
-   Each subnet validator ranks all the subnet miners by means of this weight vector. Each subnet validator within the subnet, acting independently, transmits its miner ranking weight vector to the blockchain. These ranking weight vectors can arrive at the blockchain at different times. Typically each subnet validator transmits an updated ranking weight vector to the blockchain every 100-200 blocks. 
-2. The blockchain (subtensor) waits until the latest ranking weight vectors from all the subnet validators of the given subnet arrive at the blockchain. A ranking weight matrix formed from these ranking weight vectors is then provided as input to the Yuma Consensus module on-chain.
-3. The Yuma Consensus (YC) on-chain then uses this weight matrix, along with the amount of stake associated with the UIDs on this subnet, to calculate rewards. The YC calculates how the reward TAO tokens should be distributed amongst the subnet validators and subnet miners in the subnet, i.e., amongst each UID in the subnet.  
-   
-:::tip All reward TAO tokens are newly minted. 
+:::tip note
+The tempo duration (360 blocks) is the same for all the user-created subnets. However, the timing of tempos can differ among subnets, depending on when they were created.
 :::
-4. Finally, the YC calculates a consensus distribution of TAO (the ‘emission’) and distributes the newly minted reward TAO immediately into the accounts associated with the UIDs. 
-
-### Tempo
-
-Note that subnet validators can transmit their rank weight vectors to the blockchain any time. However, for any user-created subnet, the YC for the subnet begins at every 360 blocks (=4320 seconds or 72 minutes, at 12 seconds per block) using the latest weight matrix available at the YC for the subnet. 
-
-If a ranking weight vector from the subnet validator arrives after the start of a 360-block period, then this weight vector will be used in the subsequent YC start, i.e., after the current 360 blocks have elapsed. 
-
-At the end of any 360-block period, called **tempo**, the YC concludes and the emissions (distribution of reward TAO) are complete.  This tempo value of 360 blocks is the same for all the user-created subnets. However, the YC-starts for each user-created subnet can commence at different times. 

--- a/docs/learn/anatomy-of-incentive-mechanism.md
+++ b/docs/learn/anatomy-of-incentive-mechanism.md
@@ -10,26 +10,21 @@ See [Components of the Bittensor platform](../learn/bittensor-building-blocks) f
 
 Each subnet has its own *incentive mechanism*, a scoring model that drives the behavior of its participants, and the production of the subnet's digital commodity, by defining **how validators are to evaluate miners’ work**. Miners are incentivized to optimize for this model so validators will score (or 'weight') their work highly, resulting in higher emissions. Validators are incentivized to accurately score miners' work according to the model because the algorithm penalizes departure from consensus in miner scores with lower emissions.
 
-Each validator on a subnet is responsible for periodically computing a vector of weights assigned to each miner, representing an aggregate ranking based on miners' performance. Validators transmit these **weight vectors** to the blockchain. Typically, each subnet validator transmits an updated ranking weight vector to the blockchain every 100-200 blocks.
+Each validator on a subnet is responsible for periodically computing a vector of weights assigned to each miner, representing an aggregate ranking based on the miners' performance. Validators transmit these **weight vectors** to the blockchain. Typically, each subnet validator transmits an updated ranking weight vector to the blockchain every 100-200 blocks.
 
-The Bittensor blockchain waits for the latest ranking weight vectors from all the subnet validators of a given subnet, then forms a **weight matrix** from these ranking/weight vectors, which is then provided as input to the Yuma Consensus module on-chain. Yuma Consensus (YC) uses this weight matrix, along with the amount of stake associated with each UID on the subnet, to calculate emissions to each subnet and each participant within each subnet. These emissions are finalized and debited to participants' hotkeys at the end of each *tempo* or 360 blocks.
+The Bittensor blockchain waits for the latest ranking weight vectors from all the subnet validators of a given subnet, then forms a **weight matrix** from these ranking/weight vectors, which is then provided as input to the Yuma Consensus module on-chain. Yuma Consensus (YC) uses this weight matrix, along with the amount of stake associated with each UID on the subnet, to calculate emissions to each participant within each subnet. These emissions are finalized and debited to participants' hotkeys at the end of each *tempo* or 360 blocks.
 
 :::tip note
 The tempo duration (360 blocks) is the same for all the user-created subnets. However, the timing of tempos can differ among subnets, depending on when they were created.
 :::
-
 
 ## Subnet creator responsibilities
 
 In order for a subnet to succeed, the creator must:
 
 - Design an incentive mechanism that guides miners' relentless tendency to opimize their scores (and hence emissions) toward the desired outcomes
-- Enable miner and validator participation
-- Discourage miner and validator exploits
-
-::: note
-Though a subnet incentive mechanism works in conjunction with the Yuma Consensus in the Bittensor network, you must design your subnet incentive mechanism **by treating Yuma Consensus as a black box**. 
-:::
+- Facilitate miner and validator participation
+- Prevent miner and validator exploits
 
 ### Enable participation
 
@@ -46,9 +41,9 @@ After a subnet validator registers into your subnet, they will run the validator
 
 ### Discourage exploits
 
-The incentive mechanism is ultimately the judge of subnet miner performance. When the incentive mechanism is well calibrated, it can result in a virtuous cycle in which the subnet miners continuously improve at the desired task due to competition.
+A well-designed incentive mechanism fosters a virtuous cycle, where competition drives continuous miner improvement. Conversely, a flawed mechanism encourages shortcuts and exploits that degrade the subnet’s integrity and undermine participation.
 
-On the contrary, a poorly designed incentive mechanism can result in exploits and shortcuts, which can detrimentally impact the overall quality of the subnet and discourage fair miners.
+Ensure that your IM is proofed against gaming or unintended shortcuts through thorough modeling, testing, and community vetting. As a subnet creator, expect to continuously monitor miner performance and update your IM to fine-tune it as needed.
 
 ### Design incentive mechanism
 
@@ -72,11 +67,7 @@ See [Neuron to neuron communication](./bittensor-building-blocks.md#neuron-to-ne
 
 ### Subnet task
 
-The task is one of the key components of any incentive mechanism as it defines what miners will perform as work. The task should be chosen so that miners are maximally effective at the intended use case for the subnet.
-
-In other words, **the task should mimic an intended user interaction with a subnet**. Examples of tasks are responding to natural language prompts and storing encrypted files.
-
-The task defines the scope of work that miners will undertake, and what utility the subnet can provide to users. In some cases this should be very specific (such as storage) and in other cases it can be varied (many types of natural language query).
+The task is one of the key components of any incentive mechanism as it defines what miners will perform as work. Examples of tasks are responding to natural language prompts and storing encrypted files. The task should be designed to capture intended use case for commodity to be produced by the subnet. Generally, the task should realistically mimic an intended user interaction with a subnet. 
 
 ### Subnet scoring model
 
@@ -91,7 +82,6 @@ Miners will continuously compete to achieve the highest score possible, since it
 :::tip The zen of incentive mechanisms
 Subnets should be endlessly improving.
 :::
-
 
 ## Additional Considerations for Subnet Incentive Design
 

--- a/docs/learn/anatomy-of-incentive-mechanism.md
+++ b/docs/learn/anatomy-of-incentive-mechanism.md
@@ -20,15 +20,16 @@ A subnet incentive mechanism, when running optimally on a subnet, will continuou
 ## Subnet creator responsibilities
 
 A subnet creator is responsible for:
-- Defining the specific digital task to be performed by the subnet miners.
-- Implementing an incentive mechanism that aligns miners with the desired task outcomes.
 
+- Design an incentive mechanism that aligns miners with the desired task outcomes.
+- Enable participation
+- Discourage exploits
 
-### Design with Yuma Consensus as a black box
-
+:::	note
 Though a subnet incentive mechanism works in conjunction with the Yuma Consensus in the Bittensor network, you must design your subnet incentive mechanism **by treating Yuma Consensus as a black box**. 
+:::
 
-### Make it easy for participation
+### Enable participation
 
 To attract high-performing subnet miners and subnet validators, make sure that you publish sufficient documentation on your subnet. 
 
@@ -40,6 +41,18 @@ After a subnet validator registers into your subnet, they will run the validator
 
 - [Running a validator](https://github.com/opentensor/prompting/blob/main/docs/SN1_validation.md).
 - [Running a miner](https://github.com/opentensor/prompting/blob/main/docs/stream_miner_template.md).
+
+### Discourage exploits
+
+The incentive mechanism is ultimately the judge of subnet miner performance. When the incentive mechanism is well calibrated, it can result in a virtuous cycle in which the subnet miners continuously improve at the desired task due to competition. 
+
+On the contrary, a poorly designed incentive mechanism can result in exploits and shortcuts, which can detrimentally impact the overall quality of the subnet and discourage fair miners.
+
+### Design incentive mechanism
+
+Research what other subnet creators are doing are doing.
+
+Browse the subnets and explore links to their code repositories on [Taostats' subnets listings](https://taostats.io/subnets), and learn about the latest research on subnet design, which is an active area.
 
 ## Components of incentive mechanism
 
@@ -56,16 +69,13 @@ A subnet creator must define a protocol for how validators are to query miners, 
 
 See [Neuron to neuron communication](./bittensor-building-blocks.md#neuron-to-neuron-communication).
 
-
 ### Subnet task
 
 The task is one of the key components of any incentive mechanism as it defines what miners will perform as work. The task should be chosen so that miners are maximally effective at the intended use case for the subnet.
 
 In other words, **the task should mimic an intended user interaction with a subnet**. Examples of tasks are responding to natural language prompts and storing encrypted files.
 
-:::tip Aligning miners with the subnet goals
 The task defines the scope of work that miners will undertake, and what utility the subnet can provide to users. In some cases this should be very specific (such as storage) and in other cases it can be varied (many types of natural language query). 
-:::
 
 ### Subnet scoring model
 
@@ -81,14 +91,7 @@ Miners will continuously compete to achieve the highest score possible, since it
 Subnets should be endlessly improving.
 :::
 
-### Discourage exploits
-The incentive mechanism is ultimately the judge of subnet miner performance. When the incentive mechanism is well calibrated, it can result in a virtuous cycle in which the subnet miners continuously improve at the desired task due to competition. 
-
-On the contrary, a poorly designed incentive mechanism can result in exploits and shortcuts, which can detrimentally impact the overall quality of the subnet and discourage fair miners.
-
-
 ## Allocation of emissions
-
 
 1. Each validator on the subnet computes a vector of weights assigned to each miner, representing an aggregate ranking based on their performance. Validators transmit these **weight vectors** to the blockchain. Typically each subnet validator transmits an updated ranking weight vector to the blockchain every 100-200 blocks. 
 2. The Bittensor blockchain waits for the latest ranking weight vectors from all the subnet validators of a given subnet, then forms a **weight matrix** formed from these ranking/weight vectors is then provided as input to the Yuma Consensus module on-chain.

--- a/docs/learn/anatomy-of-incentive-mechanism.md
+++ b/docs/learn/anatomy-of-incentive-mechanism.md
@@ -51,7 +51,7 @@ Research what other subnet creators are doing.
 
 Browse the subnets and explore links to their code repositories on [Taostats' subnets listings](https://taostats.io/subnets), and learn about the latest research on subnet design, which is an active area.
 
-## Components of incentive mechanism
+## Components of an incentive mechanism
 
 A subnet incentive mechanism must provide the following:
 
@@ -83,7 +83,7 @@ Miners will continuously compete to achieve the highest score possible, since it
 Subnets should be endlessly improving.
 :::
 
-## Additional Considerations for Subnet Incentive Design
+## Additional Considerations for incentive mechanism design
 
 - Take miner hardware into account, where it may cause differences in output, or in judging performance.
 - Set tight similarity thresholds if exact reproducibility is challenging. For example, compare embeddings (like CLIP) or apply perceptual hashing.  

--- a/docs/learn/anatomy-of-incentive-mechanism.md
+++ b/docs/learn/anatomy-of-incentive-mechanism.md
@@ -2,20 +2,17 @@
 title: "Understanding Incentive Mechanisms"
 ---
 
-import ThemedImage from '@theme/ThemedImage';
-import useBaseUrl from '@docusaurus/useBaseUrl';
-
 # Understanding Incentive Mechanisms
 
-This page explores the concept and usage of incentive mechansisms in Bittensor
+This page explores the concept and usage of incentive mechanisms in Bittensor.
 
 See [Components of the Bittensor platform](../learn/bittensor-building-blocks) for an explanation of the basics, such as subnets, miners, validators, and the role of the blockchain.
 
-Each subnet has its own *incentive mechanism*, which drives the behavior of its community of miners and validators by defining a standard model for how miner's work is to be evaluated. Miners are incentivized to meet this standard so validators will score (or 'weight') their work highly, resulting in higher emissions. Validators are incentivized to accurately score miners' work according to this standard because the algorithm penalizes departure from consensus in miner scores with lower emissions.
+Each subnet has its own *incentive mechanism*, which drives the behavior of its community of miners and validators by defining a standard model for how miners’ work is to be evaluated. Miners are incentivized to meet this standard so validators will score (or 'weight') their work highly, resulting in higher emissions. Validators are incentivized to accurately score miners' work according to this standard because the algorithm penalizes departure from consensus in miner scores with lower emissions.
 
 A well-designed incentive mechanism is critical for a well-functioning subnet! Carefully consider and test the consequences of the behaviors you will be incentivizing and punishing before releasing your IM to your subnet on the main Bittensor network.
 
-A subnet incentive mechanism, when running optimally on a subnet, will continuously produce high quality results because the subnet miners and subnet validators are incentivized to do so. Furthermore, a good incentive mechanism will encourage **continuous improvement** of the subnet as a whole by leveraging the competition between miners to attain ever higher scores.
+A subnet incentive mechanism, when running optimally on a subnet, will continuously produce high-quality results because the subnet miners and subnet validators are incentivized to do so. Furthermore, a good incentive mechanism will encourage **continuous improvement** of the subnet as a whole by leveraging the competition between miners to attain ever higher scores.
 
 ## Subnet creator responsibilities
 
@@ -25,32 +22,32 @@ A subnet creator is responsible for:
 - Enable participation
 - Discourage exploits
 
-:::	note
+::: note
 Though a subnet incentive mechanism works in conjunction with the Yuma Consensus in the Bittensor network, you must design your subnet incentive mechanism **by treating Yuma Consensus as a black box**. 
 :::
 
 ### Enable participation
 
-To attract high-performing subnet miners and subnet validators, make sure that you publish sufficient documentation on your subnet. 
+To attract high-performing subnet miners and subnet validators, make sure that you publish sufficient documentation on your subnet.
 
 :::tip Good docs are important!
 Make sure that your subnet documentation helps developers successfully onboard to mining and validating.
 :::
 
-After a subnet validator registers into your subnet, they will run the validator module to begin the validation operation. Similarly a subnet miner will register and then run the miner module. For example, see the following documents in the text prompting subnet for a quick view of these steps:
+After a subnet validator registers into your subnet, they will run the validator module to begin the validation operation. Similarly, a subnet miner will register and then run the miner module. For example, see the following documents in the text prompting subnet for a quick view of these steps:
 
 - [Running a validator](https://github.com/opentensor/prompting/blob/main/docs/SN1_validation.md).
 - [Running a miner](https://github.com/opentensor/prompting/blob/main/docs/stream_miner_template.md).
 
 ### Discourage exploits
 
-The incentive mechanism is ultimately the judge of subnet miner performance. When the incentive mechanism is well calibrated, it can result in a virtuous cycle in which the subnet miners continuously improve at the desired task due to competition. 
+The incentive mechanism is ultimately the judge of subnet miner performance. When the incentive mechanism is well calibrated, it can result in a virtuous cycle in which the subnet miners continuously improve at the desired task due to competition.
 
 On the contrary, a poorly designed incentive mechanism can result in exploits and shortcuts, which can detrimentally impact the overall quality of the subnet and discourage fair miners.
 
 ### Design incentive mechanism
 
-Research what other subnet creators are doing are doing.
+Research what other subnet creators are doing.
 
 Browse the subnets and explore links to their code repositories on [Taostats' subnets listings](https://taostats.io/subnets), and learn about the latest research on subnet design, which is an active area.
 
@@ -62,10 +59,9 @@ A subnet incentive mechanism must provide the following:
 - A task definition for the work miners are to perform
 - A scoring mechanism for validators to use in evaluating miners' work
 
-
 ### Miner-validator protocol
 
-A subnet creator must define a protocol for how validators are to query miners, and how miners should respond. Protocols are built using the Axon-Dendrite client-server model and and Synapse data objects.
+A subnet creator must define a protocol for how validators are to query miners, and how miners should respond. Protocols are built using the Axon-Dendrite client-server model and Synapse data objects.
 
 See [Neuron to neuron communication](./bittensor-building-blocks.md#neuron-to-neuron-communication).
 
@@ -75,15 +71,15 @@ The task is one of the key components of any incentive mechanism as it defines w
 
 In other words, **the task should mimic an intended user interaction with a subnet**. Examples of tasks are responding to natural language prompts and storing encrypted files.
 
-The task defines the scope of work that miners will undertake, and what utility the subnet can provide to users. In some cases this should be very specific (such as storage) and in other cases it can be varied (many types of natural language query). 
+The task defines the scope of work that miners will undertake, and what utility the subnet can provide to users. In some cases this should be very specific (such as storage) and in other cases it can be varied (many types of natural language query).
 
 ### Subnet scoring model
 
 Where the task describes **what** miners should do, the scoring model dictates **how** it should be done. Similarly, just as tasks should mimic user interactions, scoring models should mimic user preferences or desired outcomes.
 
-As with any machine learning model, a subnet has an objective function that it is continuously optimizing. The scoring model defines the quality of all miner behaviour in the subnet (both intended and unintended). 
+As with any machine learning model, a subnet has an objective function that it is continuously optimizing. The scoring model defines the quality of all miner behavior in the subnet (both intended and unintended).
 
-Operationally, it is the mathematical object that converts miner responses into numerical scores. A scoring model can in fact contain as many different scoring mechanisms as are necessary to align miners with the intended task. 
+Operationally, it is the mathematical object that converts miner responses into numerical scores. A scoring model can in fact contain as many different scoring mechanisms as are necessary to align miners with the intended task.
 
 Miners will continuously compete to achieve the highest score possible, since it determines their emissions. If the score is capped at an upper limit, miners may not be motivated to improve further. Hence care should be taken to enable continuous improvement of the miner, rather than stagnation.
 
@@ -93,10 +89,23 @@ Subnets should be endlessly improving.
 
 ## Allocation of emissions
 
-1. Each validator on the subnet computes a vector of weights assigned to each miner, representing an aggregate ranking based on their performance. Validators transmit these **weight vectors** to the blockchain. Typically each subnet validator transmits an updated ranking weight vector to the blockchain every 100-200 blocks. 
-2. The Bittensor blockchain waits for the latest ranking weight vectors from all the subnet validators of a given subnet, then forms a **weight matrix** formed from these ranking/weight vectors is then provided as input to the Yuma Consensus module on-chain.
-3. The Yuma Consensus (YC) uses this weight matrix, along with the amount of stake associated with each UID on the subnet, to calculate emissions to each subnet and each participant within each subnet, which are finalized and debited to participants' hotkeys at the end of each *tempo* or 360 blocks.
+1. Each validator on the subnet computes a vector of weights assigned to each miner, representing an aggregate ranking based on their performance. Validators transmit these **weight vectors** to the blockchain. Typically, each subnet validator transmits an updated ranking weight vector to the blockchain every 100-200 blocks.
+2. The Bittensor blockchain waits for the latest ranking weight vectors from all the subnet validators of a given subnet, then forms a **weight matrix** from these ranking/weight vectors, which is then provided as input to the Yuma Consensus module on-chain.
+3. The Yuma Consensus (YC) uses this weight matrix, along with the amount of stake associated with each UID on the subnet, to calculate emissions to each subnet and each participant within each subnet. These emissions are finalized and debited to participants' hotkeys at the end of each *tempo* or 360 blocks.
 
 :::tip note
 The tempo duration (360 blocks) is the same for all the user-created subnets. However, the timing of tempos can differ among subnets, depending on when they were created.
 :::
+
+## Additional Considerations for Subnet Incentive Design
+
+- Take miner hardware into account, where it may cause differences in output, or in judging performance.
+- Set tight similarity thresholds if exact reproducibility is challenging. For example, compare embeddings (like CLIP) or apply perceptual hashing.  
+- Take steps to prevent miners from precomputing or caching results:
+	- Use validator-provided random seeds; avoid letting miners control all the randomness in the output.
+	- Introduce small input variations.
+	- Ensure your scoring logic prevents partial outputs from being judged as similar to complete results.
+- Consider carefully how to balance speed, reliability, and quality.
+- Consider incorporating organic queries into the validation process.
+- Expect to frequently release updated that refine your incentive mechanism and address emergent exploits or other points of suboptimality. The best subnets update frequently, accomodating new hardware, new models, and new miner behaviors.
+- Observe other subnets. Many solutions—like adopting multi-model strategies or partial randomization—can be adapted to your own.

--- a/docs/learn/anatomy-of-incentive-mechanism.md
+++ b/docs/learn/anatomy-of-incentive-mechanism.md
@@ -83,7 +83,7 @@ Miners will continuously compete to achieve the highest score possible, since it
 Subnets should be endlessly improving.
 :::
 
-## Additional Considerations for incentive mechanism design
+## Additional considerations for incentive mechanism design
 
 - Take miner hardware into account, where it may cause differences in output, or in judging performance.
 - Set tight similarity thresholds if exact reproducibility is challenging. For example, compare embeddings (like CLIP) or apply perceptual hashing.  

--- a/docs/learn/anatomy-of-incentive-mechanism.md
+++ b/docs/learn/anatomy-of-incentive-mechanism.md
@@ -8,19 +8,24 @@ This page explores the concept and usage of incentive mechanisms in Bittensor.
 
 See [Components of the Bittensor platform](../learn/bittensor-building-blocks) for an explanation of the basics, such as subnets, miners, validators, and the role of the blockchain.
 
-Each subnet has its own *incentive mechanism*, which drives the behavior of its community of miners and validators by defining a standard model for how miners’ work is to be evaluated. Miners are incentivized to meet this standard so validators will score (or 'weight') their work highly, resulting in higher emissions. Validators are incentivized to accurately score miners' work according to this standard because the algorithm penalizes departure from consensus in miner scores with lower emissions.
+Each subnet has its own *incentive mechanism*, a scoring model that drives the behavior of its participants, and the production of the subnet's digital commodity, by defining **how validators are to evaluate miners’ work**. Miners are incentivized to optimize for this model so validators will score (or 'weight') their work highly, resulting in higher emissions. Validators are incentivized to accurately score miners' work according to the model because the algorithm penalizes departure from consensus in miner scores with lower emissions.
 
-A well-designed incentive mechanism is critical for a well-functioning subnet! Carefully consider and test the consequences of the behaviors you will be incentivizing and punishing before releasing your IM to your subnet on the main Bittensor network.
+Each validator on a subnet is responsible for periodically computing a vector of weights assigned to each miner, representing an aggregate ranking based on miners' performance. Validators transmit these **weight vectors** to the blockchain. Typically, each subnet validator transmits an updated ranking weight vector to the blockchain every 100-200 blocks.
 
-A subnet incentive mechanism, when running optimally on a subnet, will continuously produce high-quality results because the subnet miners and subnet validators are incentivized to do so. Furthermore, a good incentive mechanism will encourage **continuous improvement** of the subnet as a whole by leveraging the competition between miners to attain ever higher scores.
+The Bittensor blockchain waits for the latest ranking weight vectors from all the subnet validators of a given subnet, then forms a **weight matrix** from these ranking/weight vectors, which is then provided as input to the Yuma Consensus module on-chain. Yuma Consensus (YC) uses this weight matrix, along with the amount of stake associated with each UID on the subnet, to calculate emissions to each subnet and each participant within each subnet. These emissions are finalized and debited to participants' hotkeys at the end of each *tempo* or 360 blocks.
+
+:::tip note
+The tempo duration (360 blocks) is the same for all the user-created subnets. However, the timing of tempos can differ among subnets, depending on when they were created.
+:::
+
 
 ## Subnet creator responsibilities
 
-A subnet creator is responsible for:
+In order for a subnet to succeed, the creator must:
 
-- Design an incentive mechanism that aligns miners with the desired task outcomes.
-- Enable participation
-- Discourage exploits
+- Design an incentive mechanism that guides miners' relentless tendency to opimize their scores (and hence emissions) toward the desired outcomes
+- Enable miner and validator participation
+- Discourage miner and validator exploits
 
 ::: note
 Though a subnet incentive mechanism works in conjunction with the Yuma Consensus in the Bittensor network, you must design your subnet incentive mechanism **by treating Yuma Consensus as a black box**. 
@@ -87,15 +92,6 @@ Miners will continuously compete to achieve the highest score possible, since it
 Subnets should be endlessly improving.
 :::
 
-## Allocation of emissions
-
-1. Each validator on the subnet computes a vector of weights assigned to each miner, representing an aggregate ranking based on their performance. Validators transmit these **weight vectors** to the blockchain. Typically, each subnet validator transmits an updated ranking weight vector to the blockchain every 100-200 blocks.
-2. The Bittensor blockchain waits for the latest ranking weight vectors from all the subnet validators of a given subnet, then forms a **weight matrix** from these ranking/weight vectors, which is then provided as input to the Yuma Consensus module on-chain.
-3. The Yuma Consensus (YC) uses this weight matrix, along with the amount of stake associated with each UID on the subnet, to calculate emissions to each subnet and each participant within each subnet. These emissions are finalized and debited to participants' hotkeys at the end of each *tempo* or 360 blocks.
-
-:::tip note
-The tempo duration (360 blocks) is the same for all the user-created subnets. However, the timing of tempos can differ among subnets, depending on when they were created.
-:::
 
 ## Additional Considerations for Subnet Incentive Design
 

--- a/docs/learn/introduction.md
+++ b/docs/learn/introduction.md
@@ -19,7 +19,7 @@ The Bittensor platform consists of the following components:
 	
 	To explore existing subnets, check out [the listings on Taostats](https://taostats.io/subnets), or engage with [Bittensor subnet communities on Discord](https://discord.com/channels/799672011265015819/830068283314929684).
 
-2. The ***Bittensor blockchain*** serves as a system of record, and its token TAO (τ) serves as incentive for participation in subnet activities. Miners and validators harvest TAO based on both their performance within subnets, and on the performance of those subnets within Bittensor. Hence, emission of TAO incentivizes miners and validators to do their best, creating the perfect conditions for continuous improvement. The Bittensor blockchain records balances and transactions for miners, validators and subnet-owners, and allows arbitrary parties to stake currency into subnets in order to support their work.
+2. The ***Bittensor blockchain*** serves as a system of record, and its token TAO (τ) serves as incentive for participation in subnet activities. Miners and validators harvest TAO based on both their performance within subnets, and on the performance of those subnets within Bittensor. Hence, emission of TAO incentivizes miners and validators to do their best, creating the perfect conditions for continuous improvement. The Bittensor blockchain records balances and transactions for miners, validators and subnet creators, and allows arbitrary parties to stake currency into subnets in order to support their work.
 
 3. The ***Bittensor SDK***, which supports interactions between miners and validators within subnets, and allows all parties to interact with the blockchain as necessary.
 	
@@ -52,13 +52,6 @@ See [Running a Subnet Locally](https://github.com/opentensor/bittensor-subnet-te
 Browse the subnets and explore links to their code repositories on [Taostats' subnets listings](https://taostats.io/subnets).
 :::
 
-<!--
-
-- **Subnet owner**: When you only want to create a subnet but transfer the tasks of operating the subnet to others.
-- **Subnet validator**: When you are responsible for running the subnet validator.
-- **Subnet miner**: When you are responsible for running the subnet miner.
-- **Blockchain operator**: When you run the blockchain. This mostly applies during the offline testing of your subnet and your incentive mechanism, when you need a local emulation of the Bittensor blockchain because you are disconnected from the Bittensor network.
- -->
 ## Subnet development
 
 Whether creating a new subnet or joining a pre-existing subnet, you should always start by first testing the subnet incentive mechanism **locally**, then on the Bittensor **testchain** and finally go live by connecting to the Bittensor **mainchain**. See the below conceptual deployment diagram showing the three stages. 
@@ -76,24 +69,4 @@ sources={{
     dark: useBaseUrl('/img/docs/dark-subnet-deploy-stages.svg'),
   }}
 />
- -->
-<!-- to be fixed 
-
-When you are ready to participate in a subnet, follow these steps in the below order:
-Step 1: Run a local subnet
-
-Set up your local environment and deploy a local blockchain and a local subnet. By default all the below are run on the same computer you use locally (see the below diagram):
-
-Your local subnet with a single subnet validator and a single subnet miner.
-Your local blockchain with a single blockchain validator. 
-
-Bittensor provides all the tools, codebase, a quickstart subnet template, the minimum compute, memory and storage requirements you will need, and step-by-step instructions for you to accomplish this easily. 
-
-You will use your local Bittensor faucet to mint faucet TAO tokens in this step. Using this offline local subnet and local blockchain configuration you can:
-
-Familiarize yourself, by examining the code in the subnet template, with how incentive mechanisms are coded and configured. 
-Change the subnet template code to write your own incentive mechanism and test it locally.
-Determine the minimum compute, bandwidth, memory and storage requirements for your subnet with your own incentive mechanism. 
-Step 2: Run a Bittensor testnet
-Will continue. Start introducing the root subnet here. 
--->
+ 

--- a/docs/subnets/understanding-subnets.md
+++ b/docs/subnets/understanding-subnets.md
@@ -14,11 +14,11 @@ Emissions of TAO (τ) from Bittensor&mdash;are distributed among miners and vali
 ## Anatomy of a subnet
 
 The illustration below shows the main components of a subnet:
-1. A subnet's [incentive mechanism] defines the work that miners must perform, and the work that validators must perform to evaluate the miners' work. The incentive mechanism is unique to the subnet, and maintained off-chain by the subnet owner in the form of a code-repository that defines the interface for miners and validators to participate. For example, see [Subnet 1](https://github.com/macrocosm-os/prompting).
+1. A subnet's [incentive mechanism](../learn/anatomy-of-incentive-mechanism) defines the work that miners must perform, and the work that validators must perform to evaluate the miners' work. The incentive mechanism is unique to the subnet, and maintained off-chain by the subnet creator in the form of a code-repository that defines the interface for miners and validators to participate. For example, see [Subnet 1](https://github.com/macrocosm-os/prompting).
 2. **Miners** perform some useful work as defined in the subnet's incentive mechanism. For example, in Subnet 1, miners serve chat prompt completion.
 3. **Validators** independently evaluate the task performed by the subnet miners, according to standards defined by the subnet's incentive mechanism.
 4. Validators each score the performance of of each miner over the most recent time period. The matrix of these scores, by each validator for each miner, serves as input to **Yuma Consensus**. 
-5. The Yuma Consensus algorithm operates on-chain, and determines emissions to miners, validators, and subnet owners across the platform, based on performance.
+5. The Yuma Consensus algorithm operates on-chain, and determines emissions to miners, validators, and subnet creators across the platform, based on performance.
 
 <center>
 <ThemedImage
@@ -42,7 +42,7 @@ Subnets must compete for weight within the Bittensor network. New subnets are cr
 
 A subnet's performance is determined by Yuma Consensus over the weights given to it by [root network validators](../root-network). This group evaluates subnets based on many criteria and sets the weight competitively/relative to the other subnets, playing the same role for subnetworks that validators within each subnetwork play for miners.
 
-Any subnet has an 'immunity period' of `7 * 7200` blocks, which is equivalent to  seven days. This initial network immunity period starts when the subnet is created and its `netuid` is issued to the subnet owner. A newly created subnet starts with zero emission.
+Any subnet has an 'immunity period' of `7 * 7200` blocks, which is equivalent to  seven days. This initial network immunity period starts when the subnet is created and its `netuid` is issued to the subnet creator. A newly created subnet starts with zero emission.
 
 During this immunity period, the subnet is not at risk of being deregistered. At the end of this immunity period, if the subnet's emissions are the lowest among all the subnets, then this subnet will be deregistered when a new subnet registration request arrives. If there are several subnets with the lowest emission, then the oldest subnet among the lowest will be deregistered first, followed by the second oldest, and so on.
 


### PR DESCRIPTION
throughout the docs we are moving away from the following terms:

    reward(s)
    dividends
    distribute/distribution
    earn
    recieve/send (emissions)
    subnet owner

we prefer:

    TAO (and alpha) are emitted by Bittensor to participants
    Participants mine or extract TAO/alpha
    Allocation rather than distribution
    incentiv(e/ize) rather than reward
    Credit/debit (emissions to a participant)
    Subnet Creator
    avoid language that sounds financial

