### PR TITLE
update miner dereg docs

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -162,6 +162,8 @@ A data structure that contains comprehensive information about the current state
 
 The process of removing a poor-performing subnet miner from a UID slot, making room for a newly registered miner.
 
+See [Mining in Bittensor: Miner Deregistration](./miners/#miner-deregistration)
+
 ### Mnemonic
 
 A sequence of words used to regenerate keys, in case of loss, and restore coldkeys and hotkeys in the Bittensor wallet.

--- a/docs/miners/index.md
+++ b/docs/miners/index.md
@@ -55,9 +55,11 @@ btcli subnet register --netuid 1 --wallet.name test-coldkey --wallet.hotkey test
 
 ## Miner deregistration
 
-Miners as well as validators can be deregistered if their emissions are low. Typical subnets have 256 UID slots, including maximums of 64 validator UIDs and 192 miner UIDs. 
+Miners as well as validators can be deregistered if their emissions are low.
 
 Each tempo, the '[neuron](../learn/bittensor-building-blocks)' (miner *or* validator node) with the lowest 'pruning score' (based solely on emissions) risks being replaced by a newly registered neuron, who takes over that UID.
+
+Typical subnets have 256 UID slots, including maximums of 64 validator UIDs. This leaves 192 UIDs for miners, though if there are fewer validators, a miner can occupy one of the additional slots.
 
 In case of a tie, the older node gets deregistered first.
 

--- a/docs/miners/index.md
+++ b/docs/miners/index.md
@@ -55,19 +55,25 @@ btcli subnet register --netuid 1 --wallet.name test-coldkey --wallet.hotkey test
 
 ## Miner deregistration
 
-A subnet miner can be deregistered if its performance is poor. Mining is competitive—and the UID slots are limited. Except in Subnet 1, all subnets have 256 UID slots per subnet. Of these 256 UID slots, a subnet can have a maximum of 64 subnet validator UIDs and 192 subnet miner UIDs. Each tempo, the lowest ranked mine risks being replaced by a newly registered miner, who takes over that UID. 
+A subnet neuron (whether miner or validator) can be deregistered if its emissions are low. Mining and validating are both competitive—and the UID slots are limited. Except in Subnet 1, all subnets have 256 UID slots per subnet. Of these 256 UID slots, a subnet can have a maximum of 64 subnet validator UIDs and 192 subnet miner UIDs. 
+
+Each tempo, the neuron (miner or validator node) with the lowest 'pruning score' (based solely on emissions) risks being replaced by a newly registered neuron, who takes over that UID.
+
+:::tip Deregistration is based on emissions
+The subnet does not distinguish between miners and validators for deregistration purposes. The chain only looks at emissions/pruning scores. Whoever has the lowest emissions will get deregistered. If there's a tie, the older UID gets deregistered. The subnet owner hotkey is immune forever.
+:::
 
 - Every subnet has an `immunity_period` hyperparameter expressed in a number of blocks.
     :::tip See
     See [`immunity_period`](../subnets/subnet-hyperparameters.md#immunity_period).
     :::
-- A subnet miner or validator at a UID (in that subnet) has `immunity_period` blocks to improve its performance. When `immunity_period` expires, that miner or validator can be deregistered if it has the lowest performance in the subnet and a new registration arrives.
+- A subnet neuron (miner or validator) at a UID (in that subnet) has `immunity_period` blocks to improve its performance. When `immunity_period` expires, that miner or validator can be deregistered if it has the lowest performance in the subnet and a new registration arrives.
 - The `immunity_period` starts when a miner or validator is registered into the subnet.
 
-Below is a diagram illustrating a subnet miner’s registration timeline:
+Below is a diagram illustrating a subnet neuron's registration timeline:
 
 <ThemedImage
-alt="Miner deregistration"
+alt="Neuron deregistration"
 sources={{
     light: useBaseUrl('/img/docs/miner-deregistration.svg'),
     dark: useBaseUrl('/img/docs/dark-miner-deregistration.svg'),
@@ -84,7 +90,7 @@ style={{width: 990}}
 - At the end of the `immunity_period`, if this miner’s emission ranks the lowest among those also out of their `immunity_period`, then upon the next registration, this miner’s UID gets transferred to the new registrant.
 
 :::tip Subnet miner emission
-A subnet miner's emission may not always appear as a smooth curve. Emission might only update at the end of tempo periods, or subnet validators might do more frequent internal updates. For example, a validator might detect new miners and refresh every 100 blocks.
+Emissions may not always appear as a smooth curve. Emission might only update at the end of tempo periods, or subnet validators might do more frequent internal updates. For example, a validator might detect new miners and refresh every 100 blocks.
 :::
 
 ## Moving a subnet miner to a different machine

--- a/docs/miners/index.md
+++ b/docs/miners/index.md
@@ -57,24 +57,34 @@ btcli subnet register --netuid 1 --wallet.name test-coldkey --wallet.hotkey test
 
 Miners as well as validators can be deregistered if their emissions are low.
 
-Each tempo, the '[neuron](../learn/bittensor-building-blocks)' (miner *or* validator node) with the lowest 'pruning score' (based solely on emissions) risks being replaced by a newly registered neuron, who takes over that UID.
+Typical subnets have 256 UID slots, with a maximum of 64 slots capable of serving as validators. This leaves 192 UIDs for miners, though if there are fewer validators, a miner can occupy one of the additional slots.
 
-Typical subnets have 256 UID slots, including maximums of 64 validator UIDs. This leaves 192 UIDs for miners, though if there are fewer validators, a miner can occupy one of the additional slots.
-
-In case of a tie, the older node gets deregistered first.
-
-The subnet owner hotkey has permanent immunity from deregistration.
+Each tempo, the '[neuron](../learn/bittensor-building-blocks)' (miner *or* validator node) with the lowest 'pruning score' (based solely on emissions), and that is no longer within its [immunity period](../subnets/subnet-hyperparameters.md#immunity_period), risks being replaced by a newly registered neuron, who takes over that UID.
 
 :::info Deregistration is based on emissions
 The subnet does not distinguish between miners and validators for deregistration purposes. The chain only looks at emissions (represented as 'pruning score'). Whoever has the lowest emissions will get deregistered. 
 :::
 
+### Immunity period
+
 - Every subnet has an `immunity_period` hyperparameter expressed in a number of blocks.
     :::tip See
     See [`immunity_period`](../subnets/subnet-hyperparameters.md#immunity_period).
     :::
+
 - A subnet neuron (miner or validator) at a UID (in that subnet) has `immunity_period` blocks to improve its performance. When `immunity_period` expires, that miner or validator can be deregistered if it has the lowest performance in the subnet and a new registration arrives.
+
 - The `immunity_period` starts when a miner or validator is registered into the subnet.
+
+### Special cases
+
+In case of a tie, the older node gets deregistered first.
+
+In the unlikely event that all neurons are still immune, the one with the lowest 'pruning score' will be deregistered by the next incoming registration.
+
+The subnet owner hotkey has permanent immunity from deregistration.
+
+### Registration flow diagram
 
 Below is a diagram illustrating a subnet neuron's registration timeline:
 
@@ -110,7 +120,6 @@ To move a subnet miner from one machine to another, follow these steps in order:
 3. Stop the old miner.
 
 It can take subnet validators some time to recognize the updated IP of the Axon for your subnet miner.
-
 
 ## Inspecting UIDs
 

--- a/docs/miners/index.md
+++ b/docs/miners/index.md
@@ -9,9 +9,9 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 ## Choosing a subnet
 
-All mining in Bittensor occurs within a subnet. Each subnet independently produces the digital commodities that are its purpose, each subnet creator defining a different *incentive mechanism* for validators to use in judging miners' work. It is validators scores of miners' performance, according to this incentive mechanism, that determines the proportion of the subnet's emissions allocated to each miner. See [Emissions](../emissions.md).
+All mining in Bittensor occurs within a subnet. Each subnet independently produces the digital commodities that are its purpose, each subnet creator defining a different _incentive mechanism_ for validators to use in judging miners' work. It is validators scores of miners' performance, according to this incentive mechanism, that determines the proportion of the subnet's emissions allocated to each miner. See [Emissions](../emissions.md).
 
-Mining in Bittensor is not like mining Bitcoin or many other blockchains, it is active, creative, and competitive. Preparing to be a subnet miner involves researching the right subnet(s) for *you* to mine, given your own expertise and access to hardware.
+Mining in Bittensor is not like mining Bitcoin or many other blockchains, it is active, creative, and competitive. Preparing to be a subnet miner involves researching the right subnet(s) for _you_ to mine, given your own expertise and access to hardware.
 
 Browse the subnets and explore links to their code repositories on [TAO.app' subnets listings](https://tao.app).
 
@@ -36,7 +36,7 @@ A subnet can have a maximum of 64 subnet validator UIDs and 192 subnet miner UID
 Upon registration, your hotkey, which is part of your wallet, becomes the holder of the UID slot.
 
 :::tip Ownership belongs to a hotkey
-When you delegate your TAO to a subnet validator, you attach your delegated TAO to that validator’s hotkey. See [Delegation](../staking-and-delegation/delegation.md). 
+When you delegate your TAO to a subnet validator, you attach your delegated TAO to that validator’s hotkey. See [Delegation](../staking-and-delegation/delegation.md).
 
 A hotkey can hold multiple UIDs across **separate** subnets. However, within one subnet, each UID must have a unique hotkey.
 :::
@@ -49,6 +49,7 @@ btcli subnet register --netuid <your_preferred_netuid>  --wallet.name  <my_coldk
 ```
 
 For example, for subnet 1 (netuid of 1):
+
 ```bash
 btcli subnet register --netuid 1 --wallet.name test-coldkey --wallet.hotkey test-hotkey
 ```
@@ -57,32 +58,32 @@ btcli subnet register --netuid 1 --wallet.name test-coldkey --wallet.hotkey test
 
 Miners as well as validators can be deregistered if their emissions are low.
 
-Typical subnets have 256 UID slots, with a maximum of 64 slots capable of serving as validators. This leaves 192 UIDs for miners, though if there are fewer validators, a miner can occupy one of the additional slots.
+Typically, subnets have 256 UID slots, with a maximum of 64 slots capable of serving as validators by default. This leaves 192 UIDs for miners, though if there are fewer than 64 eligible validators on a subnet, miners can occupy one of the available slots.
 
-Each tempo, the '[neuron](../learn/bittensor-building-blocks)' (miner *or* validator node) with the lowest 'pruning score' (based solely on emissions), and that is no longer within its [immunity period](../subnets/subnet-hyperparameters.md#immunity_period), risks being replaced by a newly registered neuron, who takes over that UID.
+:::info
+Deregistration only occurs on subnets where all 256 UID slots are occupied. If a new registration occurs in a subnet with available UID slots, the registered neuron occupies one of the available UID slots.
+:::
+
+Each tempo, the '[neuron](../learn/bittensor-building-blocks)' (miner _or_ validator node) with the lowest 'pruning score' (based solely on emissions), and that is no longer within its [immunity period](../subnets/subnet-hyperparameters.md#immunityperiod), risks being replaced by a newly registered neuron, who takes over that UID.
 
 :::info Deregistration is based on emissions
-The subnet does not distinguish between miners and validators for deregistration purposes. The chain only looks at emissions (represented as 'pruning score'). Whoever has the lowest emissions will get deregistered. 
+The subnet does not distinguish between miners and validators for the purpose of deregistration. The chain only looks at emissions (represented as 'pruning score'). Whenever a new registration occurs in the subnet, the neuron with the lowest emissions will get deregistered.
 :::
 
 ### Immunity period
 
-- Every subnet has an `immunity_period` hyperparameter expressed in a number of blocks.
-    :::tip See
-    See [`immunity_period`](../subnets/subnet-hyperparameters.md#immunity_period).
-    :::
+Every subnet has an `immunity_period` hyperparameter expressed in a number of blocks. A neuron's `immunity_period` starts when the miner or validator registers into the subnet. For more information, see [`immunity_period`](../subnets/subnet-hyperparameters.md#immunityperiod).
 
-- A subnet neuron (miner or validator) at a UID (in that subnet) has `immunity_period` blocks to improve its performance. When `immunity_period` expires, that miner or validator can be deregistered if it has the lowest performance in the subnet and a new registration arrives.
+A subnet neuron (miner or validator) at a UID (in that subnet) has `immunity_period` blocks to improve its performance. When `immunity_period` expires, that miner or validator can be deregistered if it has the lowest performance in the subnet and a new registration arrives.
 
-- The `immunity_period` starts when a miner or validator is registered into the subnet.
+:::tip Special cases
 
-### Special cases
+- In the unlikely event that all neurons are still immune, the one with the lowest "pruning score" will be deregistered by the next incoming registration.
 
-In case of a tie, the older node gets deregistered first.
+- In cases where two or more nodes have the lowest "pruning score", the older node gets deregistered first.
 
-In the unlikely event that all neurons are still immune, the one with the lowest 'pruning score' will be deregistered by the next incoming registration.
-
-The subnet owner hotkey has permanent immunity from deregistration.
+- The subnet owner's hotkey has permanent immunity from deregistration.
+  :::
 
 ### Registration flow diagram
 
@@ -131,24 +132,24 @@ btcli wallet overview --netuid
 
 After providing your wallet name when prompted, you will see output such as:
 
-| Parameter   | Value                | Description                                                                 |
-| :---------- | :------------------- | :-------------------------------------------------------------------------- |
-| COLDKEY     | my_coldkey          | The name of the coldkey associated with your slot.                          |
-| HOTKEY      | my_first_hotkey     | The name of the hotkey associated with your slot.                           |
-| UID         | 5                   | The index of the uid out of available uids.                                 |
-| ACTIVE      | True                | The validator has set weights within the subnet's activity_cutoff           |
-| STAKE(τ)    | 71.296              | The amount of stake in this wallet.                                         |
-| RANK        | 0.0629              | This miner's absolute ranking according to validators on the network.       |
-| TRUST       | 0.2629              | This miner's trust as a proportion of validators on the network.            |
-| CONSENSUS   | 0.89                | This validator's aggregate consensus score.                                 |
-| INCENTIVE   | 0.029               | This miner's incentive, TAO emission, is attained via mining.               |
-| DIVIDENDS   | 0.001               | This validator's dividends, TAO emission, are attained via validating.      |
-| EMISSION    | 29_340_153          | This miner's total emission in RAO (10^(-9) TAO) per block.                 |
-| VTRUST      | 0.96936             | This validator's trust score as a validator.                                |
-| VPERMIT     | *                   | For validators: The uid is considered active for validating on this subnet. |
-| UPDATED     | 43                  | Blocks since this miner set weights on the chain.                           |
-| AXON        | 131.186.56.85:8091  | The entrypoint advertised by this miner on the bittensor blockchain.        |
-| HOTKEY_SS58 | 5F4tQyWr...         | The ss58-encoded address of the miner's hotkey.                             |
+| Parameter   | Value              | Description                                                                 |
+| :---------- | :----------------- | :-------------------------------------------------------------------------- |
+| COLDKEY     | my_coldkey         | The name of the coldkey associated with your slot.                          |
+| HOTKEY      | my_first_hotkey    | The name of the hotkey associated with your slot.                           |
+| UID         | 5                  | The index of the uid out of available uids.                                 |
+| ACTIVE      | True               | The validator has set weights within the subnet's activity_cutoff           |
+| STAKE(τ)    | 71.296             | The amount of stake in this wallet.                                         |
+| RANK        | 0.0629             | This miner's absolute ranking according to validators on the network.       |
+| TRUST       | 0.2629             | This miner's trust as a proportion of validators on the network.            |
+| CONSENSUS   | 0.89               | This validator's aggregate consensus score.                                 |
+| INCENTIVE   | 0.029              | This miner's incentive, TAO emission, is attained via mining.               |
+| DIVIDENDS   | 0.001              | This validator's dividends, TAO emission, are attained via validating.      |
+| EMISSION    | 29_340_153         | This miner's total emission in RAO (10^(-9) TAO) per block.                 |
+| VTRUST      | 0.96936            | This validator's trust score as a validator.                                |
+| VPERMIT     | \*                 | For validators: The uid is considered active for validating on this subnet. |
+| UPDATED     | 43                 | Blocks since this miner set weights on the chain.                           |
+| AXON        | 131.186.56.85:8091 | The entrypoint advertised by this miner on the bittensor blockchain.        |
+| HOTKEY_SS58 | 5F4tQyWr...        | The ss58-encoded address of the miner's hotkey.                             |
 
 ## Checking miner registration status
 
@@ -161,7 +162,7 @@ Use any of the Python snippets below:
 
 ```python
 import bittensor as bt
-# Replace below with your SS58 hotkey 
+# Replace below with your SS58 hotkey
 hotkey = "5HEo565WAy4Dbq3Sv271SAi7syBSofyfhhwRNjFNSM2gP9M2"
 network = "finney"
 sub = bt.subtensor(network)
@@ -172,7 +173,7 @@ print(f"Registration status for hotkey {hotkey} is: {sub.is_hotkey_registered(ho
 
 ```python
 import bittensor as bt
-# Replace below with your SS58 hotkey 
+# Replace below with your SS58 hotkey
 hotkey = "5HEo565WAy4Dbq3Sv271SAi7syBSofyfhhwRNjFNSM2gP9M2"
 network = "finney"
 netuid = 1 # subnet uid
@@ -188,7 +189,7 @@ else:
 
 ```python
 import bittensor as bt
-# Replace below with your SS58 hotkey 
+# Replace below with your SS58 hotkey
 hotkey = "5HEo565WAy4Dbq3Sv271SAi7syBSofyfhhwRNjFNSM2gP9M2"
 network = "finney"
 netuid = 1 # subnet uid

--- a/docs/miners/index.md
+++ b/docs/miners/index.md
@@ -23,7 +23,7 @@ Mining is not supported on Windows.
 
 ## Miner registration
 
-To participate as a miner, you must first register your keys with the subnet in order to receive a UID on that subnet.
+To participate as a miner, you must first register a hotkey with the subnet in order to receive a UID on that subnet.
 
 :::tip No need to create a subnet to mine
 You **do not** have to create a subnet to mine on the Bittensor network. Most miners work on established subnets.
@@ -55,12 +55,16 @@ btcli subnet register --netuid 1 --wallet.name test-coldkey --wallet.hotkey test
 
 ## Miner deregistration
 
-A subnet neuron (whether miner or validator) can be deregistered if its emissions are low. Mining and validating are both competitive—and the UID slots are limited. Except in Subnet 1, all subnets have 256 UID slots per subnet. Of these 256 UID slots, a subnet can have a maximum of 64 subnet validator UIDs and 192 subnet miner UIDs. 
+Miners as well as validators can be deregistered if their emissions are low. Typical subnets have 256 UID slots, including maximums of 64 validator UIDs and 192 miner UIDs. 
 
-Each tempo, the neuron (miner or validator node) with the lowest 'pruning score' (based solely on emissions) risks being replaced by a newly registered neuron, who takes over that UID.
+Each tempo, the '[neuron](../learn/bittensor-building-blocks)' (miner *or* validator node) with the lowest 'pruning score' (based solely on emissions) risks being replaced by a newly registered neuron, who takes over that UID.
 
-:::tip Deregistration is based on emissions
-The subnet does not distinguish between miners and validators for deregistration purposes. The chain only looks at emissions/pruning scores. Whoever has the lowest emissions will get deregistered. If there's a tie, the older UID gets deregistered. The subnet owner hotkey is immune forever.
+In case of a tie, the older node gets deregistered first.
+
+The subnet owner hotkey has permanent immiunity from deregistration.
+
+:::info Deregistration is based on emissions
+The subnet does not distinguish between miners and validators for deregistration purposes. The chain only looks at emissions (represented as 'pruning score'). Whoever has the lowest emissions will get deregistered. 
 :::
 
 - Every subnet has an `immunity_period` hyperparameter expressed in a number of blocks.
@@ -87,7 +91,7 @@ style={{width: 990}}
 - The subnet validators refresh their metagraph and discover the new Axon.
 - The subnet validators send requests to that Axon and evaluate its responses. This drives the subnet’s incentive mechanism, awarding emissions to the miner.
 - While still in the `immunity_period`, the subnet miner builds up its emissions from zero.
-- At the end of the `immunity_period`, if this miner’s emission ranks the lowest among those also out of their `immunity_period`, then upon the next registration, this miner’s UID gets transferred to the new registrant.
+- If the miner’s emissions rank among the lowest for nodes outside of their `immunity_period`, their UID gets transferred to the next new registrant.
 
 :::tip Subnet miner emission
 Emissions may not always appear as a smooth curve. Emission might only update at the end of tempo periods, or subnet validators might do more frequent internal updates. For example, a validator might detect new miners and refresh every 100 blocks.

--- a/docs/miners/index.md
+++ b/docs/miners/index.md
@@ -61,7 +61,7 @@ Each tempo, the '[neuron](../learn/bittensor-building-blocks)' (miner *or* valid
 
 In case of a tie, the older node gets deregistered first.
 
-The subnet owner hotkey has permanent immiunity from deregistration.
+The subnet owner hotkey has permanent immunity from deregistration.
 
 :::info Deregistration is based on emissions
 The subnet does not distinguish between miners and validators for deregistration purposes. The chain only looks at emissions (represented as 'pruning score'). Whoever has the lowest emissions will get deregistered. 

--- a/docs/miners/index.md
+++ b/docs/miners/index.md
@@ -58,7 +58,7 @@ btcli subnet register --netuid 1 --wallet.name test-coldkey --wallet.hotkey test
 
 Miners as well as validators can be deregistered if their emissions are low.
 
-Typically, subnets have 256 UID slots, with a maximum of 64 slots capable of serving as validators by default. This leaves 192 UIDs for miners, though if there are fewer than 64 eligible validators on a subnet, miners can occupy one of the available slots.
+Typically, subnets have 256 UID slots, with a maximum of 64 slots capable of serving as validators by default. This leaves 192 UIDs for miners, though if there are fewer than 64 eligible validators on a subnet, miners can occupy available slots.
 
 :::info
 Deregistration only occurs on subnets where all 256 UID slots are occupied. If a new registration occurs in a subnet with available UID slots, the registered neuron occupies one of the available UID slots.

--- a/docs/validators/index.md
+++ b/docs/validators/index.md
@@ -75,7 +75,7 @@ btcli subnet register --netuid <desired netuid> --wallet.name  <wallet name> --h
 
 Validators, like miners, can be deregistered if their emissions are low. However, validator deregistration involves additional steps compared to miner deregistration. This is because an active validator must be among the top 64 nodes in the subnet and, therefore, cannot be instantly "pruned" by a newly registered node.
 
-When a validator falls below the top 64 nodes by emissions, it loses its validation permit. If a validator loses its validation permit and has no means to gain emissions, it will eventually become the node with the lowest emission, making it eligible for deregistration.
+When a validator falls below the top 64 nodes by emissions, or has less than the required 1000 total stake weight, it loses its validation permit, but is not therefore automatically deregistered. If a validator loses its validation permit and has no means to gain emissions, it will eventually become the node with the lowest emission, making it eligible for deregistration.
 
 :::info
 Deregistration only occurs on subnets where all 256 UID slots are occupied. If a new registration occurs in a subnet with available UID slots, the registered neuron occupies one of the available UID slots.

--- a/docs/validators/index.md
+++ b/docs/validators/index.md
@@ -7,7 +7,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Validating in Bittensor
 
-All mining and validating in Bittensor occurs within a subnet. Each subnet independently produces the digital commodities that are its purpose, each subnet creator defining a different _incentive mechanism_ for validators to use in judging miners' work. The validator's work is to apply this incentive mechanism to miners, using it to score their performance, and then to submit these weights to the Bittensor blockchain. It is validators scores of miners' performance that determines the proportion of the subnet's emissions allocated to each miner, according to the Yuma Consensus algorithm. See [Emissions](../emissions.md).
+All mining and validating in Bittensor occur within a subnet. Each subnet independently produces the digital commodities that are its purpose, each subnet creator defining a different _incentive mechanism_ for validators to use in judging miners' work. The validator's work is to apply this incentive mechanism to miners, using it to score their performance, and then to submit these weights to the Bittensor blockchain. It is validators scores of miners' performance that determines the proportion of the subnet's emissions allocated to each miner, according to the Yuma Consensus algorithm. See [Emissions](../emissions.md).
 
 Browse the subnets and explore links to their code repositories on [TAO.app' subnets listings](https://tao.app).
 


### PR DESCRIPTION
based on feedback that it was confusing
"The thing is, people are confused about the distinction between validator and miner, as if the subnet is going to deregister one over the other.  As I understand it, for the purposes of deregistration, a subnet will neither know nor care whether a neuron is mining or validating. It just pays attention to the emissions/pruning score.

When I get a chance, I think I might end up submitting a modified article to help out, trexman.

Practically speaking, if someone is able to register a validator, and is in the top 64, and is operating correctly (setting weights within the activity_cutoff, not wildly out of consensus with the rest of the validators), and has a decent stake, they'd probably be pretty safe from deregistration.

And if I'm understanding this correctly, there could be an opportunity for exploitation if someone has the assets to stake and sees a subnet with a relatively small number of validators, because they could effectively become the majority consensus by which the lower-staked validators are the compared (based on stake).  But let me know if I'm not understanding this correctly.
Fish | Datura, Celium — 6:56 AM
pruning score, based on emissions, is the deciding factor for deregistrations. It has nothing to do with who is a "miner" or "validator". The chain doesn't care about that
whoever has the lowest emissions will get deregistered
if it's a tie, the older UID will get deregistered
and subnet owner hotkey is immune forever
that's all"


https://discord.com/channels/799672011265015819/917906456261578792/1379096548851585114